### PR TITLE
Remove quick actions and keep add transaction button

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -145,38 +145,23 @@
 {% endblock %}
 
 {% block content %}
-<!-- Month Selector and Quick Actions -->
+<!-- Month Selector and Add Transaction -->
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h4 class="mb-0">Dashboard</h4>
-    <div class="input-group" style="width: 200px;">
-        <button class="btn btn-sm btn-outline-secondary" onclick="changeMonth(-1)">
-            <i class="fas fa-chevron-left"></i>
+    <div class="d-flex align-items-center">
+        <button class="btn btn-modern-primary me-2" data-bs-toggle="modal" data-bs-target="#addTransactionModal">
+            <i class="fas fa-plus me-1"></i> Add Transaction
         </button>
-        <input type="month" class="form-control form-control-sm text-center" id="monthSelector" onchange="loadDashboardForMonth()">
-        <button class="btn btn-sm btn-outline-secondary" onclick="changeMonth(1)">
-            <i class="fas fa-chevron-right"></i>
-        </button>
+        <div class="input-group" style="width: 200px;">
+            <button class="btn btn-sm btn-outline-secondary" onclick="changeMonth(-1)">
+                <i class="fas fa-chevron-left"></i>
+            </button>
+            <input type="month" class="form-control form-control-sm text-center" id="monthSelector" onchange="loadDashboardForMonth()">
+            <button class="btn btn-sm btn-outline-secondary" onclick="changeMonth(1)">
+                <i class="fas fa-chevron-right"></i>
+            </button>
+        </div>
     </div>
-</div>
-
-<!-- Quick Actions Bar -->
-<div class="quick-actions-bar">
-    <span class="text-muted me-2" style="font-size: 0.813rem;">Quick Actions:</span>
-    <button class="btn btn-primary btn-sm quick-action-btn" data-bs-toggle="modal" data-bs-target="#addTransactionModal">
-        <i class="fas fa-plus"></i> Transaction
-    </button>
-    <a href="/budget" class="btn btn-outline-primary btn-sm quick-action-btn">
-        <i class="fas fa-calculator"></i> Budget
-    </a>
-    <a href="/funds" class="btn btn-outline-primary btn-sm quick-action-btn">
-        <i class="fas fa-piggy-bank"></i> Funds
-    </a>
-    <a href="/transactions" class="btn btn-outline-primary btn-sm quick-action-btn">
-        <i class="fas fa-list"></i> All Transactions
-    </a>
-    <a href="/reports" class="btn btn-outline-primary btn-sm quick-action-btn">
-        <i class="fas fa-chart-bar"></i> Reports
-    </a>
 </div>
 
 <!-- Summary Strip -->


### PR DESCRIPTION
## Summary
- remove Quick Actions bar from dashboard
- add Add Transaction button next to month selector

## Testing
- `python test_setup.py` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_688500a79dc483209d4cc65fc3951669