### PR TITLE
Fix fund category budgeting and restore decimals

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -345,8 +345,8 @@
             return new Intl.NumberFormat('en-US', {
                 style: 'currency',
                 currency: 'USD',
-                minimumFractionDigits: 0,
-                maximumFractionDigits: 0
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
             }).format(amount);
         }
         

--- a/templates/budget.html
+++ b/templates/budget.html
@@ -189,6 +189,20 @@
     </div>
 </div>
 
+<!-- Fund Expenses -->
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0">
+            <i class="fas fa-piggy-bank text-primary"></i> Fund Contributions
+        </h5>
+    </div>
+    <div class="card-body">
+        <div id="fundCategories">
+            <!-- Fund categories will be loaded here -->
+        </div>
+    </div>
+</div>
+
 <!-- Budget Comparison -->
 <div class="card">
     <div class="card-header">
@@ -252,10 +266,12 @@
             const incomeCategories = data.filter(c => c.type === 'income' && !c.name.toLowerCase().includes('deduction'));
             const deductionCategories = data.filter(c => c.type === 'income' && c.name.toLowerCase().includes('deduction'));
             const expenseCategories = data.filter(c => c.type === 'expense');
-            
+            const fundCategories = data.filter(c => c.type === 'fund');
+
             displayCategories(incomeCategories, 'incomeCategories');
             displayCategories(deductionCategories, 'deductionCategories');
             displayCategories(expenseCategories, 'expenseCategories');
+            displayCategories(fundCategories, 'fundCategories');
         });
     }
     
@@ -283,6 +299,7 @@
             // Separate by type
             const incomeItems = data.filter(item => item.type === 'income');
             const expenseItems = data.filter(item => item.type === 'expense');
+            const fundItems = data.filter(item => item.type === 'fund');
             
             // Income section
             if (incomeItems.length > 0) {
@@ -312,6 +329,26 @@
                     const statusBadge = item.status === 'over' ? 'badge-danger' : 'badge-success';
                     const statusText = item.status === 'over' ? 'Over Budget' : 'Under Budget';
                     
+                    comparisonHtml += `
+                        <tr>
+                            <td>${item.category}</td>
+                            <td class="text-end">${formatCurrency(item.budgeted)}</td>
+                            <td class="text-end">${formatCurrency(item.actual)}</td>
+                            <td class="text-end ${statusClass}">${item.difference >= 0 ? '+' : ''}${formatCurrency(item.difference)}</td>
+                            <td><span class="badge ${statusBadge}">${statusText}</span></td>
+                        </tr>
+                    `;
+                });
+            }
+
+            // Fund section
+            if (fundItems.length > 0) {
+                comparisonHtml += '<tr><td colspan="5" class="fw-bold bg-light">Fund Contributions</td></tr>';
+                fundItems.forEach(item => {
+                    const statusClass = item.status === 'over' ? 'text-danger' : 'text-success';
+                    const statusBadge = item.status === 'over' ? 'badge-danger' : 'badge-success';
+                    const statusText = item.status === 'over' ? 'Over Budget' : 'Under Budget';
+
                     comparisonHtml += `
                         <tr>
                             <td>${item.category}</td>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -375,11 +375,11 @@
     function loadDashboardData() {
         $.get(`/api/dashboard-data/${currentMonth}`, function(data) {
             // Update summary values
-            $('#netIncome').text(formatCurrency(data.net_income).replace('.00', ''));
-            $('#totalExpenses').text(formatCurrency(data.total_expenses).replace('.00', ''));
+            $('#netIncome').text(formatCurrency(data.net_income));
+            $('#totalExpenses').text(formatCurrency(data.total_expenses));
             
             const leftToBudget = data.net_income - data.total_expenses - data.total_savings;
-            $('#leftToBudget').text(formatCurrency(leftToBudget).replace('.00', ''));
+            $('#leftToBudget').text(formatCurrency(leftToBudget));
             
             const savingsRate = data.net_income > 0 ? ((data.total_savings / data.net_income) * 100).toFixed(0) : 0;
             $('#savingsRate').text(savingsRate + '%');
@@ -504,7 +504,7 @@
                         </div>
                     </div>
                     <div class="transaction-amount ${amountClass}">
-                        ${sign}${formatCurrency(trans.amount).replace('.00', '')}
+                        ${sign}${formatCurrency(trans.amount)}
                     </div>
                 </div>
             `;
@@ -525,7 +525,7 @@
                 html += '<div class="mb-2"><strong class="text-danger">Over Budget:</strong></div>';
                 overBudget.slice(0, 3).forEach(item => {
                     const overAmount = item.actual - item.budgeted;
-                    html += `<div class="ms-2 mb-1">${item.category}: <span class="text-danger">+${formatCurrency(overAmount).replace('.00', '')}</span></div>`;
+                    html += `<div class="ms-2 mb-1">${item.category}: <span class="text-danger">+${formatCurrency(overAmount)}</span></div>`;
                 });
             }
             

--- a/templates/transactions.html
+++ b/templates/transactions.html
@@ -39,9 +39,14 @@
         color: var(--success-color);
         font-weight: 600;
     }
-    
+
     .amount-negative {
         color: var(--danger-color);
+        font-weight: 600;
+    }
+
+    .amount-deduction {
+        color: var(--warning-color);
         font-weight: 600;
     }
     
@@ -62,6 +67,11 @@
     .category-expense {
         background-color: rgba(239, 68, 68, 0.1);
         color: #dc2626;
+    }
+
+    .category-deduction {
+        background-color: rgba(250, 204, 21, 0.1);
+        color: #eab308;
     }
     
     .category-fund {
@@ -382,7 +392,7 @@
             }
         } else if (transactionType === 'expense') {
             const grouped = {};
-            categories.filter(c => c.type === 'expense').forEach(cat => {
+            categories.filter(c => c.type === 'expense' || c.type === 'fund').forEach(cat => {
                 const parent = cat.parent_category || 'Other';
                 if (!grouped[parent]) grouped[parent] = [];
                 grouped[parent].push(cat);
@@ -433,10 +443,20 @@
             let html = '';
             
             transactions.forEach(trans => {
-                const typeClass = trans.type === 'income' ? 'category-income' : 
-                                trans.type === 'expense' ? 'category-expense' : 'category-fund';
-                const amountClass = trans.type === 'expense' || trans.type === 'fund_withdrawal' ? 'amount-negative' : 'amount-positive';
-                const amountSign = trans.type === 'expense' || trans.type === 'fund_withdrawal' ? '-' : '+';
+                const isDeduction = trans.type === 'income' && trans.category.toLowerCase().includes('deduction');
+                const typeClass = isDeduction ? 'category-deduction'
+                                   : trans.type === 'income' ? 'category-income'
+                                   : trans.type === 'expense' ? 'category-expense'
+                                   : 'category-fund';
+                let amountClass = 'amount-positive';
+                let amountSign = '+';
+                if (trans.type === 'expense' || trans.type === 'fund_withdrawal') {
+                    amountClass = 'amount-negative';
+                    amountSign = '-';
+                } else if (isDeduction) {
+                    amountClass = 'amount-deduction';
+                    amountSign = '-';
+                }
                 
                 html += `
                     <tr class="transaction-row">


### PR DESCRIPTION
## Summary
- show currency amounts with decimals again
- create fund categories with type `fund` and adjust transaction handling
- separate fund contributions on the budget page
- support fund categories throughout budget comparison
- color deductions yellow in transaction lists

## Testing
- `python test_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_688500e6d36883209641ec0f5d12c428