### PR TITLE
Add tooltips and getting started modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,28 @@
             box-sizing: border-box;
         }
 
+        /* Getting Started Modal */
+        .modal-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.6);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 10000;
+        }
+
+        .modal-content-simple {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            max-width: 500px;
+            width: 90%;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -294,6 +316,7 @@
                 <button class="tab-btn" onclick="switchTab('transactions', this)">Add Transaction</button>
                 <button class="tab-btn" onclick="switchTab('budget', this)">Budget Setup</button>
                 <button class="tab-btn" onclick="switchTab('import', this)">Import/Export</button>
+                <button class="btn btn-secondary" id="gettingStartedBtn" style="margin-left:auto;">Getting Started</button>
             </div>
         </div>
 
@@ -428,7 +451,16 @@
         </div>
     </div>
 
+    <div id="gettingStartedModal" class="modal-overlay">
+        <div class="modal-content-simple">
+            <h2>Getting Started</h2>
+            <p>Run <code>app.py</code> then visit <code>http://localhost:5000</code> to use the full application.</p>
+            <button id="closeGettingStarted" class="btn btn-secondary" style="margin-top:10px;">Close</button>
+        </div>
+    </div>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" crossorigin="anonymous"></script>
+    <script src="static/js/base.js"></script>
     <script>
         // Global state
         let budgetData = {
@@ -911,6 +943,17 @@
             setTimeout(() => {
                 alert.remove();
             }, 5000);
+        }
+
+        // Getting Started modal
+        const gsBtn = document.getElementById('gettingStartedBtn');
+        const gsModal = document.getElementById('gettingStartedModal');
+        const gsClose = document.getElementById('closeGettingStarted');
+        if (gsBtn) {
+            gsBtn.addEventListener('click', () => gsModal.style.display = 'flex');
+        }
+        if (gsClose) {
+            gsClose.addEventListener('click', () => gsModal.style.display = 'none');
         }
     </script>
 </body>

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -1,0 +1,5 @@
+(() => {
+    if (window.bootstrap) {
+        document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
+    }
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -345,7 +345,10 @@
     <!-- D3.js for Sankey diagrams -->
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://unpkg.com/d3-sankey@0.12.3/dist/d3-sankey.min.js"></script>
-    
+
+    <!-- Global helpers -->
+    <script src="{{ url_for('static', filename='js/base.js') }}"></script>
+
     <!-- Base JavaScript -->
     <script>
         // Format currency

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -150,7 +150,7 @@
     <h4 class="mb-0">Dashboard</h4>
     <div class="d-flex align-items-center">
         <button class="btn btn-modern-primary me-2" data-bs-toggle="modal" data-bs-target="#addTransactionModal">
-            <i class="fas fa-plus me-1"></i> Add Transaction
+            <i class="fas fa-plus me-1" data-bs-toggle="tooltip" title="Add a new transaction"></i> Add Transaction
         </button>
         <div class="input-group" style="width: 200px;">
             <button class="btn btn-sm btn-outline-secondary" onclick="changeMonth(-1)">

--- a/templates/funds.html
+++ b/templates/funds.html
@@ -216,13 +216,13 @@
                                 ` : ''}
                                 
                                 <div class="mt-3">
-                                    <button class="btn btn-sm btn-outline-primary" onclick="editFund(${fundId})">
+                                    <button class="btn btn-sm btn-outline-primary" onclick="editFund(${fundId})" title="Edit fund" data-bs-toggle="tooltip">
                                         <i class="fas fa-edit"></i> Edit
                                     </button>
-                                    <button class="btn btn-sm btn-outline-primary" onclick="withdrawFrom(${fundId}, '${fundNameEscaped}')">
+                                    <button class="btn btn-sm btn-outline-primary" onclick="withdrawFrom(${fundId}, '${fundNameEscaped}')" title="Withdraw from fund" data-bs-toggle="tooltip">
                                         <i class="fas fa-minus"></i> Withdraw
                                     </button>
-                                    <button class="btn btn-sm btn-outline-danger" onclick="deleteFund(${fundId}, '${fundNameEscaped}')">
+                                    <button class="btn btn-sm btn-outline-danger" onclick="deleteFund(${fundId}, '${fundNameEscaped}')" title="Delete fund" data-bs-toggle="tooltip">
                                         <i class="fas fa-trash"></i> Delete
                                     </button>
                                 </div>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -34,7 +34,7 @@
     <div class="col-md-6 col-lg-4 mb-4">
         <div class="card report-card text-center" onclick="showReport('monthly-summary')">
             <div class="card-body">
-                <i class="fas fa-calendar-alt report-icon"></i>
+                <i class="fas fa-calendar-alt report-icon" data-bs-toggle="tooltip" title="Monthly summary"></i>
                 <h5 class="card-title">Monthly Summary</h5>
                 <p class="card-text">View income, expenses, and savings for any month</p>
             </div>
@@ -45,7 +45,7 @@
     <div class="col-md-6 col-lg-4 mb-4">
         <div class="card report-card text-center" onclick="showReport('annual-overview')">
             <div class="card-body">
-                <i class="fas fa-chart-line report-icon"></i>
+                <i class="fas fa-chart-line report-icon" data-bs-toggle="tooltip" title="Annual overview"></i>
                 <h5 class="card-title">Annual Overview</h5>
                 <p class="card-text">Year-to-date performance and trends</p>
             </div>
@@ -56,7 +56,7 @@
     <div class="col-md-6 col-lg-4 mb-4">
         <div class="card report-card text-center" onclick="showReport('category-analysis')">
             <div class="card-body">
-                <i class="fas fa-chart-pie report-icon"></i>
+                <i class="fas fa-chart-pie report-icon" data-bs-toggle="tooltip" title="Category analysis"></i>
                 <h5 class="card-title">Category Analysis</h5>
                 <p class="card-text">Detailed breakdown by spending category</p>
             </div>
@@ -67,7 +67,7 @@
     <div class="col-md-6 col-lg-4 mb-4">
         <div class="card report-card text-center" onclick="showReport('spending-trends')">
             <div class="card-body">
-                <i class="fas fa-chart-area report-icon"></i>
+                <i class="fas fa-chart-area report-icon" data-bs-toggle="tooltip" title="Spending trends"></i>
                 <h5 class="card-title">Spending Trends</h5>
                 <p class="card-text">Track spending patterns over time</p>
             </div>
@@ -78,7 +78,7 @@
     <div class="col-md-6 col-lg-4 mb-4">
         <div class="card report-card text-center" onclick="showReport('fund-progress')">
             <div class="card-body">
-                <i class="fas fa-piggy-bank report-icon"></i>
+                <i class="fas fa-piggy-bank report-icon" data-bs-toggle="tooltip" title="Fund progress"></i>
                 <h5 class="card-title">Fund Progress</h5>
                 <p class="card-text">Track progress toward savings goals</p>
             </div>
@@ -89,7 +89,7 @@
     <div class="col-md-6 col-lg-4 mb-4">
         <div class="card report-card text-center" onclick="showExportOptions()">
             <div class="card-body">
-                <i class="fas fa-download report-icon"></i>
+                <i class="fas fa-download report-icon" data-bs-toggle="tooltip" title="Export options"></i>
                 <h5 class="card-title">Export Data</h5>
                 <p class="card-text">Download your data in various formats</p>
             </div>
@@ -117,10 +117,10 @@
                 <p>Select the format for your data export:</p>
                 <div class="d-grid gap-2">
                     <button class="btn btn-outline-primary" onclick="exportData('csv')">
-                        <i class="fas fa-file-csv"></i> Export as CSV
+                        <i class="fas fa-file-csv" data-bs-toggle="tooltip" title="Export as CSV"></i> Export as CSV
                     </button>
                     <button class="btn btn-outline-primary" onclick="exportData('json')">
-                        <i class="fas fa-file-code"></i> Export as JSON
+                        <i class="fas fa-file-code" data-bs-toggle="tooltip" title="Export as JSON"></i> Export as JSON
                     </button>
                 </div>
             </div>

--- a/templates/transactions.html
+++ b/templates/transactions.html
@@ -109,7 +109,7 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h4 class="mb-0">Transactions</h4>
     <button class="btn btn-modern-primary" data-bs-toggle="modal" data-bs-target="#addTransactionModal">
-        <i class="fas fa-plus me-1"></i> Add Transaction
+        <i class="fas fa-plus me-1" data-bs-toggle="tooltip" title="Add a new transaction"></i> Add Transaction
     </button>
 </div>
 
@@ -470,10 +470,10 @@
                         <td class="${amountClass} text-end">${amountSign}${formatCurrency(trans.amount)}</td>
                         <td>
                             <div class="action-buttons text-end">
-                                <button class="btn btn-sm btn-link text-primary p-1" onclick="editTransaction(${trans.id})">
+                                <button class="btn btn-sm btn-link text-primary p-1" onclick="editTransaction(${trans.id})" title="Edit transaction" data-bs-toggle="tooltip">
                                     <i class="fas fa-edit"></i>
                                 </button>
-                                <button class="btn btn-sm btn-link text-danger p-1" onclick="deleteTransaction(${trans.id})">
+                                <button class="btn btn-sm btn-link text-danger p-1" onclick="deleteTransaction(${trans.id})" title="Delete transaction" data-bs-toggle="tooltip">
                                     <i class="fas fa-trash"></i>
                                 </button>
                             </div>


### PR DESCRIPTION
## Summary
- enable Bootstrap tooltips globally
- show tooltip help on action icons
- document icons in the reports page
- add a simple Getting Started modal on the landing page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6886535c30b88320aac161b09d3f666a