### PR TITLE
Fix responsive table container

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -41,3 +41,9 @@ body {
 [data-theme='dark'] .text-muted {
   color: #adb5bd !important;
 }
+
+@media (max-width: 768px) {
+  .table-responsive {
+    overflow-x: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- allow table scrolling on small screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888f3ed19cc8320a05f6dffe8143774