### PR TITLE
Use collapse for add forms

### DIFF
--- a/templates/budget.html
+++ b/templates/budget.html
@@ -31,7 +31,6 @@
         padding: 20px;
         border-radius: 8px;
         margin-top: 20px;
-        display: none;
     }
 
     .editable-budget {
@@ -77,7 +76,7 @@
     <div class="card-header">
         <h5 class="mb-0">
             <i class="fas fa-arrow-up text-success"></i> Income Sources
-            <button class="btn btn-sm btn-light float-end ms-2" onclick="showAddCategoryForm('income')">
+            <button class="btn btn-sm btn-light float-end ms-2" onclick="toggleAddCategoryForm('income')">
                 <i class="fas fa-plus"></i> Add Income
             </button>
             <button class="btn btn-sm btn-light float-end" onclick="addGroup('income')">
@@ -89,7 +88,7 @@
         <div id="incomeCategories">
             <!-- Income categories will be loaded here -->
         </div>
-        <div class="add-category-form" id="addIncomeForm">
+        <div class="add-category-form collapse" id="addIncomeForm">
             <h6>Add Income Category</h6>
             <form onsubmit="addCategory(event, 'income')">
                 <div class="row">
@@ -114,7 +113,7 @@
     <div class="card-header">
         <h5 class="mb-0">
             <i class="fas fa-minus-circle text-warning"></i> Deductions
-            <button class="btn btn-sm btn-light float-end ms-2" onclick="showAddCategoryForm('deduction')">
+            <button class="btn btn-sm btn-light float-end ms-2" onclick="toggleAddCategoryForm('deduction')">
                 <i class="fas fa-plus"></i> Add Deduction
             </button>
             <button class="btn btn-sm btn-light float-end" onclick="addGroup('income')">
@@ -126,7 +125,7 @@
         <div id="deductionCategories">
             <!-- Deduction categories will be loaded here -->
         </div>
-        <div class="add-category-form" id="addDeductionForm">
+        <div class="add-category-form collapse" id="addDeductionForm">
             <h6>Add Deduction Category</h6>
             <form onsubmit="addCategory(event, 'deduction')">
                 <div class="row">
@@ -151,7 +150,7 @@
     <div class="card-header">
         <h5 class="mb-0">
             <i class="fas fa-arrow-down text-danger"></i> Expense Categories
-            <button class="btn btn-sm btn-light float-end ms-2" onclick="showAddCategoryForm('expense')">
+            <button class="btn btn-sm btn-light float-end ms-2" onclick="toggleAddCategoryForm('expense')">
                 <i class="fas fa-plus"></i> Add Expense
             </button>
             <button class="btn btn-sm btn-light float-end" onclick="addGroup('expense')">
@@ -163,7 +162,7 @@
         <div id="expenseCategories">
             <!-- Expense categories will be loaded here -->
         </div>
-        <div class="add-category-form" id="addExpenseForm">
+        <div class="add-category-form collapse" id="addExpenseForm">
             <h6>Add Expense Category</h6>
             <form onsubmit="addCategory(event, 'expense')">
                 <div class="row">
@@ -490,20 +489,26 @@
         }
     }
     
+    function toggleAddCategoryForm(type) {
+        const formType = type === 'deduction' ? 'Deduction' : type.charAt(0).toUpperCase() + type.slice(1);
+        const el = document.getElementById('add' + formType + 'Form');
+        const collapse = bootstrap.Collapse.getOrCreateInstance(el);
+        collapse.toggle();
+    }
+
     function showAddCategoryForm(type) {
         const formType = type === 'deduction' ? 'Deduction' : type.charAt(0).toUpperCase() + type.slice(1);
-        $('#add' + formType + 'Form').slideDown();
+        const el = document.getElementById('add' + formType + 'Form');
+        const collapse = bootstrap.Collapse.getOrCreateInstance(el);
+        collapse.show();
     }
-    
+
     function hideAddCategoryForm(type) {
         const formType = type === 'deduction' ? 'Deduction' : type.charAt(0).toUpperCase() + type.slice(1);
-        const form = $('#add' + formType + 'Form');
-        form.slideUp();
-        form.find('form')[0].reset();
-        // Ensure the form is hidden
-        setTimeout(() => {
-            form.hide();
-        }, 500);
+        const el = document.getElementById('add' + formType + 'Form');
+        const collapse = bootstrap.Collapse.getOrCreateInstance(el);
+        collapse.hide();
+        el.querySelector('form').reset();
     }
     
     function addCategory(event, type) {

--- a/templates/funds.html
+++ b/templates/funds.html
@@ -45,7 +45,7 @@
     <div class="col-12">
         <h1 class="mb-4">
             <i class="fas fa-piggy-bank"></i> Savings Funds
-            <button class="btn btn-modern-primary float-end" data-bs-toggle="modal" data-bs-target="#addFundModal">
+            <button class="btn btn-modern-primary float-end" onclick="toggleAddFundForm()">
                 <i class="fas fa-plus"></i> Create Fund
             </button>
         </h1>
@@ -56,43 +56,40 @@
     <!-- Funds will be loaded here -->
 </div>
 
-<!-- Add Fund Modal -->
-<div class="modal fade" id="addFundModal" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Create New Fund</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <div class="modal-body">
-                <form id="addFundForm">
-                    <div class="mb-3">
-                        <label class="form-label">Fund Name</label>
-                        <input type="text" class="form-control" name="name" required>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Current Balance</label>
-                        <input type="number" class="form-control" name="current_balance" step="0.01" value="0" required>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Goal Amount</label>
-                        <input type="number" class="form-control" name="goal_amount" step="0.01" required>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Target Date</label>
-                        <input type="date" class="form-control" name="goal_date" required>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Monthly Contribution</label>
-                        <input type="number" class="form-control" name="monthly_contribution" step="0.01" value="0">
-                        <small class="form-text text-muted">This will be added to your budget as a monthly expense</small>
-                    </div>
-                </form>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-modern-primary" onclick="saveFund()">Create Fund</button>
-            </div>
+<!-- Add Fund Form -->
+<div class="collapse" id="addFundModal">
+    <div class="card mt-3">
+        <div class="card-header">
+            <h5 class="mb-0">Create New Fund</h5>
+        </div>
+        <div class="card-body">
+            <form id="addFundForm">
+                <div class="mb-3">
+                    <label class="form-label">Fund Name</label>
+                    <input type="text" class="form-control" name="name" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Current Balance</label>
+                    <input type="number" class="form-control" name="current_balance" step="0.01" value="0" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Goal Amount</label>
+                    <input type="number" class="form-control" name="goal_amount" step="0.01" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Target Date</label>
+                    <input type="date" class="form-control" name="goal_date" required>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Monthly Contribution</label>
+                    <input type="number" class="form-control" name="monthly_contribution" step="0.01" value="0">
+                    <small class="form-text text-muted">This will be added to your budget as a monthly expense</small>
+                </div>
+            </form>
+        </div>
+        <div class="card-footer text-end">
+            <button type="button" class="btn btn-secondary" onclick="toggleAddFundForm(false)">Cancel</button>
+            <button type="button" class="btn btn-modern-primary" onclick="saveFund()">Create Fund</button>
         </div>
     </div>
 </div>
@@ -246,6 +243,14 @@
         
         return months > 0 ? months : 0;
     }
+
+    function toggleAddFundForm(show) {
+        const el = document.getElementById('addFundModal');
+        const collapse = bootstrap.Collapse.getOrCreateInstance(el);
+        if (show === true) collapse.show();
+        else if (show === false) collapse.hide();
+        else collapse.toggle();
+    }
     
     function saveFund() {
         const formData = $('#addFundForm').serializeArray();
@@ -260,7 +265,7 @@
             contentType: 'application/json',
             data: JSON.stringify(data),
             success: function() {
-                $('#addFundModal').modal('hide');
+                toggleAddFundForm(false);
                 $('#addFundForm')[0].reset();
                 showToast('Fund created successfully! Check your budget to see the monthly contribution.', 'success');
                 loadFunds();


### PR DESCRIPTION
## Summary
- toggle Add Category forms with Bootstrap's Collapse widget
- switch fund creation modal to a collapsible card

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888f5b45db88320bd520f37e2af7822