### PR TITLE
Fix growing report page

### DIFF
--- a/templates/reports.html
+++ b/templates/reports.html
@@ -131,8 +131,13 @@
 
 {% block extra_js %}
 <script>
+    let activeChart = null;
     function showReport(reportType) {
         $('#reportDisplay').show();
+        if (activeChart) {
+            activeChart.destroy();
+            activeChart = null;
+        }
         $('#reportContent').html('<div class="text-center"><div class="spinner-border text-primary" role="status"></div><p>Loading report...</p></div>');
         
         // Scroll to report
@@ -282,7 +287,10 @@
             
             // Create the trend chart
             const ctx = document.getElementById('monthlyTrendChart').getContext('2d');
-            new Chart(ctx, {
+            if (activeChart) {
+                activeChart.destroy();
+            }
+            activeChart = new Chart(ctx, {
                 type: 'line',
                 data: {
                     labels: data.months,
@@ -328,13 +336,14 @@
     
     function loadCategoryAnalysis() {
         const currentMonth = new Date().toISOString().slice(0, 7);
-        $.get(`/api/reports/category-analysis/${currentMonth}`, function(data) {
+        const month = $('#categoryMonth').val() || currentMonth;
+        $.get(`/api/reports/category-analysis/${month}`, function(data) {
             let chartHtml = `
                 <h3>Category Analysis</h3>
                 <div class="mb-4">
                     <label>Select Month:</label>
-                    <input type="month" class="form-control" style="width: 200px; display: inline-block; margin-left: 10px;" 
-                           id="categoryMonth" value="${currentMonth}" onchange="loadCategoryAnalysis()">
+                    <input type="month" class="form-control" style="width: 200px; display: inline-block; margin-left: 10px;"
+                           id="categoryMonth" value="${month}" onchange="loadCategoryAnalysis()">
                 </div>
                 <div class="row">
                     <div class="col-md-6">
@@ -375,7 +384,10 @@
             
             // Create pie chart
             const ctx = document.getElementById('categoryPieChart').getContext('2d');
-            new Chart(ctx, {
+            if (activeChart) {
+                activeChart.destroy();
+            }
+            activeChart = new Chart(ctx, {
                 type: 'pie',
                 data: {
                     labels: data.categories.map(c => c.name),
@@ -448,7 +460,10 @@
             
             // Create trend chart
             const ctx = document.getElementById('spendingTrendChart').getContext('2d');
-            new Chart(ctx, {
+            if (activeChart) {
+                activeChart.destroy();
+            }
+            activeChart = new Chart(ctx, {
                 type: 'bar',
                 data: {
                     labels: data.months,


### PR DESCRIPTION
## Summary
- make report charts destroy previous Chart.js instances
- use selected month in category analysis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6888fca23b808320b0708d16d9b294e8