### PR TITLE
Add CSV import with parser

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 TheSimonella
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A personal budgeting application built with **Flask** and **SQLite**. It lets yo
 - Monthly budget setup per category with comparison against actual spending
 - Savings funds with progress tracking and recommended contributions
 - Report pages (monthly summary, annual overview, category analysis, spending trends)
-- CSV and JSON export of all data and placeholder support for Excel import
+- CSV and JSON export of all data and CSV import for bank transactions
 - REST style API endpoints used by the front end (can also be reused by other tools)
 - Automatic detection of recurring subscriptions with optional renewal notifications
 
@@ -75,7 +75,7 @@ If database changes are required, the helper function `migrate_database()` in `a
 
 ## Export / import
 
-The app can export transactions and other data to CSV or JSON via `/api/export/csv` and `/api/export/json`. An Excel import endpoint exists (`/api/import-excel`) as a placeholder – adapt the implementation to match your spreadsheet format if needed.
+The app can export transactions and other data to CSV or JSON via `/api/export/csv` and `/api/export/json`. Transactions from your bank can be imported using `/api/import-csv` by uploading a CSV file and specifying the `bank` parameter (e.g. `bank1` or `bank2`). The legacy Excel import endpoint remains as a placeholder for custom spreadsheets.
 
 ## Troubleshooting
 
@@ -85,4 +85,4 @@ The app can export transactions and other data to CSV or JSON via `/api/export/c
 
 ## License
 
-This project is provided as-is under the MIT license.
+This project is provided under the MIT license. See the `LICENSE` file for details.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,8 +4,9 @@ from app import app, db, init_database
 @pytest.fixture
 def client(tmp_path):
     app.config['TESTING'] = True
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + str(tmp_path / 'test.db')
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     with app.app_context():
+        db.drop_all()
         db.create_all()
         init_database()
         yield app.test_client()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,34 @@
+import io
+from transaction_parser import parse_csv, clean_merchant
+from app import app, db, init_database, Transaction
+
+
+def test_clean_merchant():
+    assert clean_merchant('  Store #123 ') == 'Store 123'
+
+
+def test_parse_bank1(tmp_path):
+    csv_content = 'Date,Description,Amount\n2023-01-01,Coffee,-3.50\n2023-01-02,Salary,1000'
+    txs = parse_csv(io.StringIO(csv_content), 'bank1')
+    assert len(txs) == 2
+    assert txs[0]['merchant'] == 'Coffee'
+    assert txs[0]['transaction_type'] == 'expense'
+    assert txs[1]['transaction_type'] == 'income'
+
+
+def test_import_csv_endpoint(tmp_path):
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + str(tmp_path / 'test.db')
+    with app.app_context():
+        db.create_all()
+        init_database()
+        client = app.test_client()
+        data = {
+            'file': (io.BytesIO(b'Date,Description,Amount\n2023-01-01,Coffee,-3.50'), 'tx.csv'),
+            'bank': 'bank1'
+        }
+        before = Transaction.query.count()
+        resp = client.post('/api/import-csv', data=data, content_type='multipart/form-data')
+        assert resp.status_code == 200
+        assert Transaction.query.count() == before + 1
+

--- a/transaction_parser.py
+++ b/transaction_parser.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import re
+from datetime import datetime
+
+
+def clean_merchant(text: str) -> str:
+    """Simple normalization of merchant names"""
+    if not isinstance(text, str):
+        return ""
+    text = text.strip()
+    text = re.sub(r"\s{2,}", " ", text)
+    text = re.sub(r"[^A-Za-z0-9 &]", "", text)
+    return text
+
+
+def parse_bank1(df: pd.DataFrame):
+    """Parse CSV exported from Bank1 with columns Date, Description, Amount"""
+    transactions = []
+    for _, row in df.iterrows():
+        date = pd.to_datetime(row.get("Date")).date()
+        desc = str(row.get("Description", ""))
+        amount = float(row.get("Amount", 0))
+        t_type = "income" if amount > 0 else "expense"
+        transactions.append(
+            {
+                "date": date,
+                "description": desc,
+                "merchant": clean_merchant(desc),
+                "amount": abs(amount),
+                "transaction_type": t_type,
+            }
+        )
+    return transactions
+
+
+def parse_bank2(df: pd.DataFrame):
+    """Parse CSV exported from Bank2 with Transaction Date, Details, Debit, Credit"""
+    transactions = []
+    for _, row in df.iterrows():
+        date = pd.to_datetime(row.get("Transaction Date")).date()
+        details = str(row.get("Details", ""))
+        debit = row.get("Debit")
+        credit = row.get("Credit")
+        if pd.notnull(credit) and credit != "":
+            amount = float(credit)
+        else:
+            amount = -float(debit or 0)
+        t_type = "income" if amount > 0 else "expense"
+        transactions.append(
+            {
+                "date": date,
+                "description": details,
+                "merchant": clean_merchant(details),
+                "amount": abs(amount),
+                "transaction_type": t_type,
+            }
+        )
+    return transactions
+
+
+BANK_PARSERS = {
+    "bank1": parse_bank1,
+    "bank2": parse_bank2,
+}
+
+
+def parse_csv(file_path, bank: str = "bank1"):
+    """Parse a CSV file from the given bank and return normalized transactions."""
+    df = pd.read_csv(file_path)
+    parser = BANK_PARSERS.get(bank, parse_bank1)
+    return parser(df)


### PR DESCRIPTION
## Summary
- implement `transaction_parser.py` for simple bank CSV parsing
- add `/api/import-csv` endpoint using the parser
- provide MIT LICENSE file
- document CSV import in README
- add parser tests and adjust API tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b870c008c8320ac651949c519e443