### PR TITLE
Fix date shift when editing transactions

### DIFF
--- a/static/js/base.js
+++ b/static/js/base.js
@@ -44,3 +44,14 @@ function setButtonLoading(button, loading) {
     button.html(button.data('original-text'));
   }
 }
+
+// Parse a YYYY-MM-DD string as a local Date object
+function parseLocalDate(dateString) {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+// Format a YYYY-MM-DD string to the user's locale without timezone shift
+function formatLocalDate(dateString) {
+  return parseLocalDate(dateString).toLocaleDateString();
+}

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -203,7 +203,7 @@
                     <div class="transaction-details">
                         <div style="font-weight: 500;">${trans.description}</div>
                         <div style="font-size: 0.75rem; color: #6c757d;">
-                            ${trans.category} • ${new Date(trans.date).toLocaleDateString()}
+                            ${trans.category} • ${formatLocalDate(trans.date)}
                         </div>
                     </div>
                     <div class="transaction-amount ${amountClass}">

--- a/static/js/transactions.js
+++ b/static/js/transactions.js
@@ -361,8 +361,18 @@
                         description: tx.description,
                         notes: tx.notes
                     };
-                    $(`tr[data-id="${editingTransactionId}"]`).remove();
-                    if (shouldDisplayTransaction(trans)) {
+                    const row = $(`tr[data-id="${editingTransactionId}"]`);
+                    if (!shouldDisplayTransaction(trans)) {
+                        row.remove();
+                        checkEmptyState();
+                        return;
+                    }
+
+                    const oldDate = row.data('date');
+                    if (oldDate === trans.date) {
+                        row.replaceWith(renderTransactionRow(trans));
+                    } else {
+                        row.remove();
                         insertTransactionRow(trans);
                     }
                     checkEmptyState();

--- a/static/js/transactions.js
+++ b/static/js/transactions.js
@@ -165,7 +165,7 @@
 
         return `
             <tr class="transaction-row" data-id="${trans.id}" data-date="${trans.date}">
-                <td>${new Date(trans.date).toLocaleDateString()}</td>
+                <td>${formatLocalDate(trans.date)}</td>
                 <td>
                     <div class="fw-medium">${trans.description}</div>
                     ${trans.notes ? `<small class="text-muted">${trans.notes}</small>` : ''}
@@ -218,8 +218,8 @@
         const row = $(renderTransactionRow(trans));
         let inserted = false;
         tbody.children('tr').each(function() {
-            const rowDate = new Date($(this).data('date'));
-            if (new Date(trans.date) > rowDate) {
+            const rowDate = parseLocalDate($(this).data('date'));
+            if (parseLocalDate(trans.date) > rowDate) {
                 $(this).before(row);
                 inserted = true;
                 return false;


### PR DESCRIPTION
## Summary
- prevent timezone shifts by parsing YYYY-MM-DD strings as local dates
- render and insert transactions using local date formatting
- show recent transaction dates correctly on dashboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895139e73588320a7bf0016c3e07e5a