### PR TITLE
Ensure fund balance updates reflect edited contributions

### DIFF
--- a/static/js/funds.js
+++ b/static/js/funds.js
@@ -217,3 +217,13 @@
             });
         }
     }
+
+    function refreshFunds() {
+        $.post('/api/funds/refresh', function() {
+            showToast('Funds refreshed successfully!', 'success');
+            loadFunds();
+        }).fail(function(xhr) {
+            const error = xhr.responseJSON?.error || 'Unknown error';
+            showToast('Error refreshing funds: ' + error, 'error');
+        });
+    }

--- a/templates/funds.html
+++ b/templates/funds.html
@@ -11,6 +11,9 @@
     <div class="col-12">
         <h1 class="mb-4">
             <i class="fas fa-piggy-bank"></i> Savings Funds
+            <button class="btn btn-outline-secondary float-end me-2" onclick="refreshFunds()">
+                <i class="fas fa-sync"></i> Refresh
+            </button>
             <button class="btn btn-modern-primary float-end" onclick="toggleAddFundForm()">
                 <i class="fas fa-plus"></i> Create Fund
             </button>


### PR DESCRIPTION
## Summary
- Add backend and UI controls to refresh fund balances when using old data
- Reverse fund contribution coloring so extra contributions display as green
- Show deductions as a single block and individual expenses in dashboard Sankey
- Test fund balance refresh logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a20e3efb88320a52b76528d46a6dc